### PR TITLE
Add basic product/comment services

### DIFF
--- a/ServiceCommentaire/Controllers/CommentController.cs
+++ b/ServiceCommentaire/Controllers/CommentController.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServiceCommentaire.Models;
+
+namespace ServiceCommentaire.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CommentController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+
+        public CommentController(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<object>> GetComment(int id)
+        {
+            var comment = await _context.Comments
+                .Include(c => c.Product)
+                .FirstOrDefaultAsync(c => c.Id == id);
+
+            if (comment == null)
+                return NotFound();
+
+            var result = new
+            {
+                comment.Id,
+                comment.Text,
+                comment.Rating,
+                ProductName = comment.Product?.Name
+            };
+
+            return Ok(result);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Comment>> CreateComment(Comment comment)
+        {
+            var product = await _context.Products.FindAsync(comment.ProductId);
+            if (product == null || !product.Notable)
+            {
+                return BadRequest("Cannot add comment to non-notable product.");
+            }
+
+            _context.Comments.Add(comment);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(GetComment), new { id = comment.Id }, comment);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateComment(int id, Comment updated)
+        {
+            if (id != updated.Id)
+                return BadRequest();
+
+            _context.Entry(updated).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteComment(int id)
+        {
+            var comment = await _context.Comments.FindAsync(id);
+            if (comment == null)
+                return NotFound();
+
+            _context.Comments.Remove(comment);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/ServiceCommentaire/Models/AppDbContext.cs
+++ b/ServiceCommentaire/Models/AppDbContext.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ServiceCommentaire.Models
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Product> Products => Set<Product>();
+        public DbSet<Comment> Comments => Set<Comment>();
+    }
+}

--- a/ServiceCommentaire/Models/Comment.cs
+++ b/ServiceCommentaire/Models/Comment.cs
@@ -1,0 +1,11 @@
+namespace ServiceCommentaire.Models
+{
+    public class Comment
+    {
+        public int Id { get; set; }
+        public string Text { get; set; } = string.Empty;
+        public int Rating { get; set; }
+        public int ProductId { get; set; }
+        public Product? Product { get; set; }
+    }
+}

--- a/ServiceCommentaire/Models/Product.cs
+++ b/ServiceCommentaire/Models/Product.cs
@@ -1,0 +1,11 @@
+namespace ServiceCommentaire.Models
+{
+    public class Product
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public decimal Price { get; set; }
+        public bool Notable { get; set; }
+        public ICollection<Comment>? Comments { get; set; }
+    }
+}

--- a/ServiceCommentaire/Program.cs
+++ b/ServiceCommentaire/Program.cs
@@ -1,4 +1,6 @@
 
+using Microsoft.EntityFrameworkCore;
+
 namespace ServiceCommentaire
 {
     public class Program
@@ -10,6 +12,8 @@ namespace ServiceCommentaire
             // Add services to the container.
 
             builder.Services.AddControllers();
+            builder.Services.AddDbContext<Models.AppDbContext>(opt =>
+                opt.UseInMemoryDatabase("comments"));
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();

--- a/ServiceCommentaire/ServiceCommentaire.csproj
+++ b/ServiceCommentaire/ServiceCommentaire.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ServiceProduit/Controllers/ProductController.cs
+++ b/ServiceProduit/Controllers/ProductController.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using ServiceProduit.Models;
+
+namespace ServiceProduit.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ProductController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+
+        public ProductController(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<object>>> GetProducts()
+        {
+            var products = await _context.Products
+                .Include(p => p.Comments)
+                .ToListAsync();
+
+            var result = products.Select(p => new
+            {
+                p.Id,
+                p.Name,
+                p.Price,
+                p.Notable,
+                AverageRating = p.Comments.Any() ? p.Comments.Average(c => c.Rating) : 0
+            });
+
+            return Ok(result);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<object>> GetProduct(int id)
+        {
+            var product = await _context.Products
+                .Include(p => p.Comments)
+                .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (product == null)
+                return NotFound();
+
+            var result = new
+            {
+                product.Id,
+                product.Name,
+                product.Price,
+                product.Notable,
+                AverageRating = product.Comments.Any() ? product.Comments.Average(c => c.Rating) : 0,
+                Comments = product.Comments.Select(c => new { c.Id, c.Text, c.Rating })
+            };
+
+            return Ok(result);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Product>> CreateProduct(Product product)
+        {
+            _context.Products.Add(product);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(GetProduct), new { id = product.Id }, product);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateProduct(int id, Product updated)
+        {
+            if (id != updated.Id)
+                return BadRequest();
+
+            _context.Entry(updated).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteProduct(int id)
+        {
+            var product = await _context.Products
+                .Include(p => p.Comments)
+                .FirstOrDefaultAsync(p => p.Id == id);
+            if (product == null)
+                return NotFound();
+
+            if (product.Comments.Any())
+                return BadRequest("Cannot delete a product with comments.");
+
+            _context.Products.Remove(product);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}

--- a/ServiceProduit/Models/AppDbContext.cs
+++ b/ServiceProduit/Models/AppDbContext.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace ServiceProduit.Models
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Product> Products => Set<Product>();
+        public DbSet<Comment> Comments => Set<Comment>();
+    }
+}

--- a/ServiceProduit/Models/Comment.cs
+++ b/ServiceProduit/Models/Comment.cs
@@ -1,0 +1,11 @@
+namespace ServiceProduit.Models
+{
+    public class Comment
+    {
+        public int Id { get; set; }
+        public string Text { get; set; } = string.Empty;
+        public int Rating { get; set; }
+        public int ProductId { get; set; }
+        public Product? Product { get; set; }
+    }
+}

--- a/ServiceProduit/Models/Product.cs
+++ b/ServiceProduit/Models/Product.cs
@@ -1,0 +1,11 @@
+namespace ServiceProduit.Models
+{
+    public class Product
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public decimal Price { get; set; }
+        public bool Notable { get; set; }
+        public ICollection<Comment>? Comments { get; set; }
+    }
+}

--- a/ServiceProduit/Program.cs
+++ b/ServiceProduit/Program.cs
@@ -1,4 +1,6 @@
 
+using Microsoft.EntityFrameworkCore;
+
 namespace ServiceProduit
 {
     public class Program
@@ -10,6 +12,8 @@ namespace ServiceProduit
             // Add services to the container.
 
             builder.Services.AddControllers();
+            builder.Services.AddDbContext<Models.AppDbContext>(opt =>
+                opt.UseInMemoryDatabase("products"));
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();

--- a/ServiceProduit/ServiceProduit.csproj
+++ b/ServiceProduit/ServiceProduit.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add Entity Framework Core to each project
- define product and comment models with in-memory db contexts
- implement CRUD APIs for products and comments with basic business rules

## Testing
- `dotnet build ServiceProduit.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbef7bb28832692c3ba9d4a329aa0