### PR TITLE
Switch to MySQL

### DIFF
--- a/ServiceCommentaire/Program.cs
+++ b/ServiceCommentaire/Program.cs
@@ -13,7 +13,9 @@ namespace ServiceCommentaire
 
             builder.Services.AddControllers();
             builder.Services.AddDbContext<Models.AppDbContext>(opt =>
-                opt.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+                opt.UseMySql(
+                    builder.Configuration.GetConnectionString("DefaultConnection"),
+                    ServerVersion.AutoDetect(builder.Configuration.GetConnectionString("DefaultConnection"))));
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();

--- a/ServiceCommentaire/ServiceCommentaire.csproj
+++ b/ServiceCommentaire/ServiceCommentaire.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ServiceCommentaire/appsettings.Development.json
+++ b/ServiceCommentaire/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=servicecommentaire;Username=postgres;Password=postgres"
+    "DefaultConnection": "Server=localhost;Database=servicecommentaire;User=root;Password=password"
   }
 }

--- a/ServiceCommentaire/appsettings.json
+++ b/ServiceCommentaire/appsettings.json
@@ -8,6 +8,6 @@
   "AllowedHosts": "*"
   ,
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=servicecommentaire;Username=postgres;Password=postgres"
+    "DefaultConnection": "Server=localhost;Database=servicecommentaire;User=root;Password=password"
   }
 }

--- a/ServiceProduit/Program.cs
+++ b/ServiceProduit/Program.cs
@@ -13,7 +13,9 @@ namespace ServiceProduit
 
             builder.Services.AddControllers();
             builder.Services.AddDbContext<Models.AppDbContext>(opt =>
-                opt.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+                opt.UseMySql(
+                    builder.Configuration.GetConnectionString("DefaultConnection"),
+                    ServerVersion.AutoDetect(builder.Configuration.GetConnectionString("DefaultConnection"))));
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();

--- a/ServiceProduit/ServiceProduit.csproj
+++ b/ServiceProduit/ServiceProduit.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ServiceProduit/appsettings.Development.json
+++ b/ServiceProduit/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=serviceproduit;Username=postgres;Password=postgres"
+    "DefaultConnection": "Server=localhost;Database=serviceproduit;User=root;Password=password"
   }
 }

--- a/ServiceProduit/appsettings.json
+++ b/ServiceProduit/appsettings.json
@@ -8,6 +8,6 @@
   "AllowedHosts": "*"
   ,
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Database=serviceproduit;Username=postgres;Password=postgres"
+    "DefaultConnection": "Server=localhost;Database=serviceproduit;User=root;Password=password"
   }
 }


### PR DESCRIPTION
## Summary
- use `Pomelo.EntityFrameworkCore.MySql` provider
- configure contexts to use MySQL connection strings
- update connection strings for MySQL

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685bc3d402148326b67e6aa6e61396c5