### PR TITLE
Fix gateway HTTP scheme

### DIFF
--- a/Gateway/Program.cs
+++ b/Gateway/Program.cs
@@ -11,8 +11,6 @@ builder.Services.AddDiscoveryClient(builder.Configuration);
 
 var app = builder.Build();
 
-app.UseHttpsRedirection();
-
 await app.UseOcelot();
 
 app.Run();

--- a/ServiceCommentaire/Program.cs
+++ b/ServiceCommentaire/Program.cs
@@ -43,8 +43,6 @@ namespace ServiceCommentaire
                 app.UseSwaggerUI();
             }
 
-            app.UseHttpsRedirection();
-
             app.UseAuthorization();
 
 

--- a/ServiceLecture/Program.cs
+++ b/ServiceLecture/Program.cs
@@ -39,7 +39,6 @@ namespace ServiceLecture
                 app.UseSwaggerUI();
             }
 
-            app.UseHttpsRedirection();
             app.UseAuthorization();
 
             app.MapControllers();

--- a/ServiceProduit/Program.cs
+++ b/ServiceProduit/Program.cs
@@ -43,8 +43,6 @@ namespace ServiceProduit
                 app.UseSwaggerUI();
             }
 
-            app.UseHttpsRedirection();
-
             app.UseAuthorization();
 
 


### PR DESCRIPTION
## Summary
- remove `UseHttpsRedirection` from Gateway and all microservices
  to avoid socket errors when using HTTP

## Testing
- `dotnet build ServiceProduit.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6f383c648326b07a801e461c9d02