### PR TITLE
Add Swagger support to gateway

### DIFF
--- a/Gateway/Gateway.csproj
+++ b/Gateway/Gateway.csproj
@@ -9,5 +9,6 @@
     <PackageReference Include="Ocelot.Provider.Eureka" Version="17.0.0" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="3.1.4" />
     <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 </Project>

--- a/Gateway/Program.cs
+++ b/Gateway/Program.cs
@@ -2,6 +2,7 @@ using Ocelot.DependencyInjection;
 using Ocelot.Middleware;
 using Ocelot.Provider.Eureka;
 using Steeltoe.Discovery.Client;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -9,8 +10,16 @@ builder.Configuration.AddJsonFile("ocelot.json", optional: false, reloadOnChange
 
 builder.Services.AddOcelot().AddEureka();
 builder.Services.AddDiscoveryClient(builder.Configuration);
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
 
 await app.UseOcelot();
 


### PR DESCRIPTION
## Summary
- enable Swagger in Gateway project
- add Swashbuckle dependency

## Testing
- `dotnet build ServiceProduit.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e716307688326b32de1d0903e6824